### PR TITLE
Enable full Blogger sync with pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ and displayed.
 Create an `.env.local` file using `.env.example` and set your `BLOGGER_API_KEY`
 and `BLOGGER_BLOG_ID` to import posts and comments from Blogger.
 
+To retrieve all posts from the very beginning, send a request to
+`/api/posts?refresh=1&fetchAll=1`. The server will paginate through the Blogger
+API with small delays between requests to minimize load.
+
 ## Getting Started
 
 First, run the development server:

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -7,7 +7,8 @@ export async function GET(req: NextRequest) {
   if (refresh) {
     const apiKey = process.env.BLOGGER_API_KEY || '';
     const blogId = process.env.BLOGGER_BLOG_ID || '';
-    const posts = await fetchFromBlogger(apiKey, blogId);
+    const fetchAll = searchParams.get('fetchAll') === '1';
+    const posts = await fetchFromBlogger(apiKey, blogId, fetchAll);
     return NextResponse.json(posts);
   }
   return NextResponse.json(getAllPosts());

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -49,6 +49,17 @@ export default function PostsPage() {
       });
   };
 
+  const fullRefresh = () => {
+    fetch('/api/posts?refresh=1&fetchAll=1')
+      .then(res => res.json())
+      .then(setPosts)
+      .then(() => {
+        fetch('/api/comments?refresh=1').then(() => {
+          setComments({});
+        });
+      });
+  };
+
   const create = async () => {
     const res = await fetch('/api/posts', {
       method: 'POST',
@@ -71,6 +82,12 @@ export default function PostsPage() {
       <h1 className="text-xl font-bold">Posts</h1>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={refresh}>
         Refresh from Blogger
+      </button>
+      <button
+        className="bg-blue-500 text-white px-2 py-1 ml-2"
+        onClick={fullRefresh}
+      >
+        Full Sync from Start
       </button>
       <div className="space-y-2">
         <input

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise<void>(res => setTimeout(res, ms));


### PR DESCRIPTION
## Summary
- add sleep utility
- paginate Blogger API requests to retrieve all posts and comments from the start
- allow `/api/posts?refresh=1&fetchAll=1` for full sync
- add optional full sync button in posts page
- document full sync option

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e26e09df48332a80d8479c1fd3ba8